### PR TITLE
instana-java-sdk: added tag for overriding call name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
 sudo: false
-
+jdk:
+  - openjdk8
 script: mvn -f instana-java-sdk/pom.xml clean verify

--- a/instana-java-sdk-sample/src/main/java/com/acme/batch/CustomBatchJob.java
+++ b/instana-java-sdk-sample/src/main/java/com/acme/batch/CustomBatchJob.java
@@ -1,10 +1,10 @@
 package com.acme.batch;
 
-import com.instana.sdk.annotation.Span;
-import com.instana.sdk.support.SpanSupport;
-
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+
+import com.instana.sdk.annotation.Span;
+import com.instana.sdk.support.SpanSupport;
 
 public class CustomBatchJob {
 
@@ -12,11 +12,12 @@ public class CustomBatchJob {
    * This instrumentation will create traces for each invocation of this "batch job". The Instana default
    * instrumentation will not see it, as no standard framework, like Spring Batch, is used.
    */
-  @Span(value = "my-custom-batch", captureArguments = true, captureReturn = true)
+  @Span(type = Span.Type.ENTRY, value = "my-custom-batch", captureArguments = true, captureReturn = true)
   public boolean run(String key) {
     try {
       Random random = new Random();
       Thread.sleep(TimeUnit.SECONDS.toMillis(random.nextInt(4))); // do hard work
+	    SpanSupport.annotate(Span.Type.ENTRY, "my-custom-batch", "tags.call", "call-name");
       SpanSupport.annotate(Span.Type.INTERMEDIATE, "my-custom-batch", "between-jobs", Long.toString(System.currentTimeMillis()));
       Thread.sleep(TimeUnit.SECONDS.toMillis(random.nextInt(4))); // do hard work
       return true;


### PR DESCRIPTION
Annotation with `data.sdk.custom.tags.name` can be used to override call name, default being `data.sdk.name`. Annotate add values to `data.sdk.custom`, so only `tags.name` should be used.