### PR TITLE
Provide a convenience method to restore trace context stored in a map…

### DIFF
--- a/instana-java-sdk/src/main/java/com/instana/sdk/support/SpanSupport.java
+++ b/instana-java-sdk/src/main/java/com/instana/sdk/support/SpanSupport.java
@@ -345,4 +345,23 @@ public class SpanSupport {
       map.put(LEVEL, "1");
     }
   }
+
+  /*
+   * Restore the trace context from the provided {@code map} argument, provided that it contains
+   * {@link SpanSupport#TRACE_ID} and {@link SpanSupport#SPAN_ID} as keys.
+   *
+   * The values of the {@link SpanSupport#TRACE_ID} and {@link SpanSupport#SPAN_ID} keys are passed
+   * to the {@link #inheritNext(String, String)} method.
+   *
+   * @return {@code true} if {@link SpanSupport#TRACE_ID} and {@link SpanSupport#SPAN_ID} are found in the map and the
+   *    trace context is restored; {@code false} if {@code map} is {@code null}, or it does not contain both
+   *    {@link SpanSupport#TRACE_ID} and {@link SpanSupport#SPAN_ID} as keys.
+   */
+  public static boolean continueTraceIfTracing(Map<? super String, ? super String> map) {
+    if (map != null && map.contains(TRACE_ID) && map.contains(SPAN_ID)) {
+      inheritNext(map.get(TRACE_ID), map.get(SPAN_ID));
+      return true;
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
… object

Introduce a specular operation to `inheritNext`, that will look the `X-INSTANA-T` and `X-INSTANA-S` as keys in the provided map, and use their values to restore the trace context for the next spans.