### PR TITLE
Add license headers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = false
+max_line_length = 120
+tab_width = 2

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Pre-commit script to ensure the required IBM/Instana
+# license headers are added to the relevant source files.
+# Note that if you bypass this pre-commit git hook and didn't
+# run the maven command mentioned below to add the license headers
+# to new files, the build will fail.
+
+echo
+echo Running "${BASH_SOURCE[0]}"
+echo
+
+command_exists () {
+  command -v "$1" >/dev/null 2>&1
+}
+
+command_exists mvn || {
+	echo >&2 "Can't find 'mvn' in PATH. Please ensure you have installed Maven."
+	exit 1
+}
+
+echo "Check license headers..."
+echo "=================================="
+mvn --quiet validate license:check
+MVN_STATUS=$?
+
+if [ $MVN_STATUS -eq 0 ]; then
+	echo -e "All licenses are in place. \n"
+else
+  echo "=================================="
+	echo -e >&2 "Some licenses are missing. Please run 'mvn validate license:format'. \n"
+	exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -98,3 +98,8 @@ This depends on the host that should be monitored, e.g. the number of Docker con
 
 ### How should the agent environment be configured?
 See https://docs.instana.io/quick_start/agent_configuration/
+
+# Copyright header / checks
+
+Every source file contains a copyright header. If you are creating new files you can add those by running the command: `mvn validate license:format`.
+Furthermore, a git hook check the headers in the `pre-commit` phase.

--- a/instana-java-sdk-sample/custom-http-sample/src/main/java/com/instana/sample/App.java
+++ b/instana-java-sdk-sample/custom-http-sample/src/main/java/com/instana/sample/App.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.sample;
 
 import com.instana.sample.http.custom.CustomHttpFramework;

--- a/instana-java-sdk-sample/custom-http-sample/src/main/java/com/instana/sample/GreetingHandler.java
+++ b/instana-java-sdk-sample/custom-http-sample/src/main/java/com/instana/sample/GreetingHandler.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.sample;
 
 import java.io.BufferedReader;

--- a/instana-java-sdk-sample/custom-http-sample/src/main/java/com/instana/sample/http/custom/CustomHttpFramework.java
+++ b/instana-java-sdk-sample/custom-http-sample/src/main/java/com/instana/sample/http/custom/CustomHttpFramework.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.sample.http.custom;
 
 import java.io.BufferedReader;

--- a/instana-java-sdk-sample/custom-http-sample/src/main/java/com/instana/sample/http/jetty/JettyServer.java
+++ b/instana-java-sdk-sample/custom-http-sample/src/main/java/com/instana/sample/http/jetty/JettyServer.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.sample.http.jetty;
 
 import org.eclipse.jetty.server.Server;

--- a/instana-java-sdk-sample/custom-http-sample/src/main/java/com/instana/sample/http/jetty/NameServlet.java
+++ b/instana-java-sdk-sample/custom-http-sample/src/main/java/com/instana/sample/http/jetty/NameServlet.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.sample.http.jetty;
 
 import javax.servlet.http.HttpServlet;

--- a/instana-java-sdk-sample/custom-http-sample/src/main/java/com/instana/sample/http/jetty/RootServlet.java
+++ b/instana-java-sdk-sample/custom-http-sample/src/main/java/com/instana/sample/http/jetty/RootServlet.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.sample.http.jetty;
 
 import java.io.BufferedReader;

--- a/instana-java-sdk-sample/custom-scheduler-sample/src/main/java/com/instana/sample/App.java
+++ b/instana-java-sdk-sample/custom-scheduler-sample/src/main/java/com/instana/sample/App.java
@@ -1,3 +1,8 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
+
 package com.instana.sample;
 
 import com.instana.sample.http.jetty.HelloWorldServlet;

--- a/instana-java-sdk-sample/custom-scheduler-sample/src/main/java/com/instana/sample/HttpClientJob.java
+++ b/instana-java-sdk-sample/custom-scheduler-sample/src/main/java/com/instana/sample/HttpClientJob.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.sample;
 
 import java.io.BufferedReader;

--- a/instana-java-sdk-sample/custom-scheduler-sample/src/main/java/com/instana/sample/http/jetty/HelloWorldServlet.java
+++ b/instana-java-sdk-sample/custom-scheduler-sample/src/main/java/com/instana/sample/http/jetty/HelloWorldServlet.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.sample.http.jetty;
 
 import javax.servlet.http.HttpServlet;

--- a/instana-java-sdk-sample/custom-scheduler-sample/src/main/java/com/instana/sample/http/jetty/JettyServer.java
+++ b/instana-java-sdk-sample/custom-scheduler-sample/src/main/java/com/instana/sample/http/jetty/JettyServer.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.sample.http.jetty;
 
 import org.eclipse.jetty.server.Server;

--- a/instana-java-sdk-sample/custom-scheduler-sample/src/main/java/com/instana/sample/http/jetty/NameServlet.java
+++ b/instana-java-sdk-sample/custom-scheduler-sample/src/main/java/com/instana/sample/http/jetty/NameServlet.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.sample.http.jetty;
 
 import javax.servlet.http.HttpServlet;

--- a/instana-java-sdk-sample/custom-scheduler-sample/src/main/java/com/instana/sample/scheduler/CustomScheduler.java
+++ b/instana-java-sdk-sample/custom-scheduler-sample/src/main/java/com/instana/sample/scheduler/CustomScheduler.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.sample.scheduler;
 
 import java.util.concurrent.Callable;

--- a/instana-java-sdk/pom.xml
+++ b/instana-java-sdk/pom.xml
@@ -117,6 +117,56 @@
           <source>8</source>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>timestamp-property</id>
+            <configuration>
+              <name>current.year</name>
+              <locale>en_US</locale>
+              <pattern>yyyy</pattern>
+              <unit>year</unit>
+            </configuration>
+            <goals>
+              <goal>timestamp-property</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>4.0.rc2</version>
+        <configuration>
+          <useDefaultExcludes>true</useDefaultExcludes>
+          <aggregate>false</aggregate>
+          <defaultProperties>
+            <!--suppress MavenModelInspection -->
+            <currentYear>${current.year}</currentYear>
+          </defaultProperties>
+          <licenseSets>
+            <licenseSet>
+              <header>${project.basedir}/../license-header.txt</header>
+              <includes>
+                <include>**/src/main/java/**/*.java</include>
+                <include>**/src/test/java/**/*.java</include>
+              </includes>
+            </licenseSet>
+          </licenseSets>
+        </configuration>
+        <executions>
+          <execution>
+            <id>license-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <resources>
       <resource>

--- a/instana-java-sdk/src/main/java/com/instana/sdk/annotation/Span.java
+++ b/instana-java-sdk/src/main/java/com/instana/sdk/annotation/Span.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.sdk.annotation;
 
 import java.lang.annotation.ElementType;

--- a/instana-java-sdk/src/main/java/com/instana/sdk/annotation/TagParam.java
+++ b/instana-java-sdk/src/main/java/com/instana/sdk/annotation/TagParam.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.sdk.annotation;
 
 import java.lang.annotation.ElementType;

--- a/instana-java-sdk/src/main/java/com/instana/sdk/annotation/TagReturn.java
+++ b/instana-java-sdk/src/main/java/com/instana/sdk/annotation/TagReturn.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.sdk.annotation;
 
 import java.lang.annotation.ElementType;

--- a/instana-java-sdk/src/main/java/com/instana/sdk/support/ContextSupport.java
+++ b/instana-java-sdk/src/main/java/com/instana/sdk/support/ContextSupport.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.sdk.support;
 
 public class ContextSupport {

--- a/instana-java-sdk/src/main/java/com/instana/sdk/support/SpanSupport.java
+++ b/instana-java-sdk/src/main/java/com/instana/sdk/support/SpanSupport.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.sdk.support;
 
 import java.util.Map;

--- a/license-header.txt
+++ b/license-header.txt
@@ -1,0 +1,2 @@
+(c) Copyright IBM Corp. ${currentYear}
+(c) Copyright Instana Inc.

--- a/pom.xml
+++ b/pom.xml
@@ -69,4 +69,122 @@
     <module>instana-java-sdk-sample</module>
   </modules>
 
+  <profiles>
+    <profile>
+      <id>withoutLicense</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <!-- here there must be the same identifier as defined in <build><plugins> section -->
+                <id>license-check</id>
+                <!-- this disables plugin -->
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+  <build>
+    <plugins>
+      <!-- Directory plugin to find parent root directory absolute path -->
+      <plugin>
+        <groupId>org.commonjava.maven.plugins</groupId>
+        <artifactId>directory-maven-plugin</artifactId>
+        <version>0.3.1</version>
+        <executions>
+          <execution>
+            <id>directories</id>
+            <goals>
+              <goal>directory-of</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <property>main.basedir</property>
+              <project>
+                <groupId>com.instana</groupId>
+                <artifactId>instana-java-sdk-parent</artifactId>
+              </project>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>timestamp-property</id>
+            <configuration>
+              <name>current.year</name>
+              <locale>en_US</locale>
+              <pattern>yyyy</pattern>
+              <unit>year</unit>
+            </configuration>
+            <goals>
+              <goal>timestamp-property</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>4.0.rc2</version>
+        <configuration>
+          <useDefaultExcludes>true</useDefaultExcludes>
+          <aggregate>false</aggregate>
+          <defaultProperties>
+            <!--suppress MavenModelInspection -->
+            <currentYear>${current.year}</currentYear>
+          </defaultProperties>
+          <licenseSets>
+            <licenseSet>
+              <!--suppress MavenModelInspection -->
+              <header>${main.basedir}/license-header.txt</header>
+              <includes>
+                <include>**/src/main/java/**/*.java</include>
+                <include>**/src/test/java/**/*.java</include>
+              </includes>
+            </licenseSet>
+          </licenseSets>
+        </configuration>
+        <executions>
+          <execution>
+            <id>license-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.rudikershaw.gitbuildhook</groupId>
+        <artifactId>git-build-hook-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <inherited>false</inherited>
+        <configuration>
+          <installHooks>
+            <pre-commit>.githooks/pre-commit</pre-commit>
+          </installHooks>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>install</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
This adds the mandatory IBM and Instana license headers to all Java files.

Furthermore the `license-maven-plugin` is configured to check the headers during build and in a git `pre-commit` hook.