### PR TITLE
Update Jetty dependencies in sample applications

### DIFF
--- a/instana-java-sdk-sample/custom-http-sample/pom.xml
+++ b/instana-java-sdk-sample/custom-http-sample/pom.xml
@@ -25,12 +25,12 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.28.v20200408</version>
+      <version>9.4.39.v20210325</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.28.v20200408</version>
+      <version>9.4.39.v20210325</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/instana-java-sdk-sample/custom-scheduler-sample/pom.xml
+++ b/instana-java-sdk-sample/custom-scheduler-sample/pom.xml
@@ -25,12 +25,12 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.28.v20200408</version>
+      <version>9.4.39.v20210325</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.28.v20200408</version>
+      <version>9.4.39.v20210325</version>
     </dependency>
     <dependency>
       <groupId>org.quartz-scheduler</groupId>


### PR DESCRIPTION
The used Jetty version had security issues and needed an update.